### PR TITLE
접속 상태 추적 기능 추가 및 JSP/API 예외 처리 분리

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
 		<dependency>
 		    <groupId>ch.qos.logback</groupId>
 		    <artifactId>logback-classic</artifactId>
-		    <version>1.2.3</version> <!-- 또는 너 프로젝트에 맞는 버전 -->
+		    <version>1.2.3</version>
 		</dependency>
 
 		<!-- Test -->

--- a/src/main/java/com/sist/web/chat/group/controller/ErrorTestController.java
+++ b/src/main/java/com/sist/web/chat/group/controller/ErrorTestController.java
@@ -1,0 +1,12 @@
+package com.sist.web.chat.group.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ErrorTestController {
+	@GetMapping("/err/test/view")
+	public String errTest() {
+		throw new RuntimeException("강제 예외 발생");
+	}
+}

--- a/src/main/java/com/sist/web/chat/websocket/listener/WebSocketPresenceListener.java
+++ b/src/main/java/com/sist/web/chat/websocket/listener/WebSocketPresenceListener.java
@@ -1,0 +1,37 @@
+package com.sist.web.chat.websocket.listener;
+
+import java.security.Principal;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.sist.web.common.util.OnlineUserManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class WebSocketPresenceListener {
+	@EventListener
+	public void handleConnect(SessionConnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		Principal user = accessor.getUser();
+		
+		if (user != null) {
+			String userNo = user.getName();
+			OnlineUserManager.addSession(userNo, sessionId);
+			log.info("접속: userNo = {}, sessionId = {}", userNo, sessionId);
+		}
+	}
+	
+	@EventListener
+	public void handleDisconnect(SessionDisconnectEvent event) {
+		String sessionId = event.getSessionId();
+		OnlineUserManager.removeSession(sessionId);
+		log.info("연결 종료: sessionId = {}", sessionId);
+	}
+}

--- a/src/main/java/com/sist/web/common/exception/base/GlobalExceptionHandler.java
+++ b/src/main/java/com/sist/web/common/exception/base/GlobalExceptionHandler.java
@@ -6,13 +6,14 @@ import java.time.LocalDateTime;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.sist.web.common.exception.code.CommonErrorCode;
 
 import lombok.extern.slf4j.Slf4j;
 
-@RestControllerAdvice
+@RestControllerAdvice(annotations = RestController.class)
 @Slf4j
 public class GlobalExceptionHandler {
 	@ExceptionHandler(BaseCustomException.class)

--- a/src/main/java/com/sist/web/common/exception/base/GlobalViewExceptionHandler.java
+++ b/src/main/java/com/sist/web/common/exception/base/GlobalViewExceptionHandler.java
@@ -1,8 +1,25 @@
 package com.sist.web.common.exception.base;
 
-import org.springframework.web.bind.annotation.ControllerAdvice;
 
-@ControllerAdvice
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.ModelAndView;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ControllerAdvice(annotations = Controller.class)
+@Slf4j
 public class GlobalViewExceptionHandler {
-	
+	@ExceptionHandler(Exception.class)
+	public ModelAndView handleViewException(Exception ex, HttpServletRequest request) {
+		log.error("View 예외 발생: {}", ex.getMessage(), ex);
+		
+		ModelAndView mv = new ModelAndView("main/error");
+		mv.addObject("error", "예상치 못한 에러 발생");
+		mv.addObject("message", ex.getMessage());
+		mv.addObject("status", 500);
+		return mv;
+	}
 }

--- a/src/main/java/com/sist/web/common/exception/code/CommonErrorCode.java
+++ b/src/main/java/com/sist/web/common/exception/code/CommonErrorCode.java
@@ -7,8 +7,8 @@ import com.sist.web.common.exception.base.ErrorInfo;
 public enum CommonErrorCode implements ErrorInfo {
 
 	INVALID_INPUT("C001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
-    INTERNAL_ERROR("C999", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    FORBIDDEN("C403", "권한이 없습니다.", HttpStatus.FORBIDDEN);
+	FORBIDDEN("C403", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+    INTERNAL_ERROR("C999", "서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/sist/web/common/exception/code/CommonErrorCode.java
+++ b/src/main/java/com/sist/web/common/exception/code/CommonErrorCode.java
@@ -1,9 +1,10 @@
 package com.sist.web.common.exception.code;
 
 import org.springframework.http.HttpStatus;
-
 import com.sist.web.common.exception.base.ErrorInfo;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorInfo {
 
 	INVALID_INPUT("C001", "잘못된 입력입니다.", HttpStatus.BAD_REQUEST),
@@ -14,11 +15,6 @@ public enum CommonErrorCode implements ErrorInfo {
     private final String message;
     private final HttpStatus status;
 
-    CommonErrorCode(String code, String message, HttpStatus status) {
-        this.code = code;
-        this.message = message;
-        this.status = status;
-    }
 
     public String getCode() { return code; }
     public String getMessage() { return message; }

--- a/src/main/java/com/sist/web/common/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/sist/web/common/exception/code/GroupErrorCode.java
@@ -1,9 +1,10 @@
 package com.sist.web.common.exception.code;
 
 import org.springframework.http.HttpStatus;
-
 import com.sist.web.common.exception.base.ErrorInfo;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public enum GroupErrorCode implements ErrorInfo {
 	GROUP_NOT_FOUND("G404", "그룹이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_GROUP("G409", "이미 존재하는 그룹입니다.", HttpStatus.CONFLICT);
@@ -12,11 +13,6 @@ public enum GroupErrorCode implements ErrorInfo {
     private final String message;
     private final HttpStatus status;
 
-    GroupErrorCode(String code, String message, HttpStatus status) {
-        this.code = code;
-        this.message = message;
-        this.status = status;
-    }
 
     public String getCode() { return code; }
     public String getMessage() { return message; }

--- a/src/main/java/com/sist/web/common/util/OnlineUserManager.java
+++ b/src/main/java/com/sist/web/common/util/OnlineUserManager.java
@@ -1,0 +1,38 @@
+package com.sist.web.common.util;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+
+public class OnlineUserManager {
+
+	private static final Map<String, Set<String>> userSessions = new ConcurrentHashMap<>();
+	
+	public static void addSession(String userNo, String sessionId) {
+		userSessions.compute(userNo, (key, sessions) -> {
+			if (sessions == null) {
+				sessions = new ConcurrentSkipListSet<>();
+			}
+			sessions.add(sessionId);
+			return sessions;
+		});
+	}
+	
+	public static void removeSession(String sessionId) {
+		for (Map.Entry<String, Set<String>> entry : userSessions.entrySet()) {
+			Set<String> sessions = entry.getValue();
+			if (sessions.remove(sessionId)) {
+				if (sessions.isEmpty()) {
+					userSessions.remove(entry.getKey());
+				}
+				break;
+			}
+		}
+	}
+	
+	public static Set<String> getOnlineUsers() {
+		return userSessions.keySet();
+	}
+}

--- a/src/main/webapp/WEB-INF/views/main/error.jsp
+++ b/src/main/webapp/WEB-INF/views/main/error.jsp
@@ -11,6 +11,7 @@
     <title>에러</title>
 </head>
 <body>
+  <p>${status}</p>
   <p>${error}</p>
   <p>${message}</p>
   <p>에러페이지 커스텀 예정. (error, message에 setattribute 하면 출력 가능)</p>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1" xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_1.xsd">
     <servlet>
         <servlet-name>dispatcher</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
@@ -14,6 +14,7 @@
 		    <param-name>throwExceptionIfNoHandlerFound</param-name>
 		    <param-value>true</param-value>
 		</init-param>
+		<async-supported>true</async-supported>
     </servlet>
     <servlet-mapping>
         <servlet-name>dispatcher</servlet-name>
@@ -42,6 +43,7 @@
             <param-name>forceEncoding</param-name>
             <param-value>true</param-value>
         </init-param>
+        <async-supported>true</async-supported>
     </filter>
     <filter-mapping>
         <filter-name>encodingFilter</filter-name>
@@ -50,6 +52,7 @@
     <filter>
         <filter-name>springSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+        <async-supported>true</async-supported>
     </filter>
     <filter-mapping>
         <filter-name>springSecurityFilterChain</filter-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -10,11 +10,24 @@
             <param-value>/WEB-INF/config/application-*.xml</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
+        <init-param>
+		    <param-name>throwExceptionIfNoHandlerFound</param-name>
+		    <param-value>true</param-value>
+		</init-param>
     </servlet>
     <servlet-mapping>
         <servlet-name>dispatcher</servlet-name>
         <url-pattern>/</url-pattern>
     </servlet-mapping>
+    <error-page>
+	    <error-code>404</error-code>
+	    <location>/WEB-INF/views/main/error.jsp</location><!-- 404 Not Found 페이지 -->
+	</error-page>
+	
+	<error-page>
+	    <error-code>500</error-code>
+	    <location>/WEB-INF/views/main/error.jsp</location><!-- 500 Internal Server Error 페이지 -->
+	</error-page>
     <!-- 한글 변환 -->
     <filter>
         <filter-name>encodingFilter</filter-name>

--- a/src/main/webapp/resources/js/groupchat.js
+++ b/src/main/webapp/resources/js/groupchat.js
@@ -39,6 +39,8 @@
                     
                     const socket = new SockJS(`${contextPath}/ws`);
                     this.stompClient = Stomp.over(socket);
+                    this.stompClient.heartbeat.outgoing = 10000; // client -> server
+                    this.stompClient.heartbeat.incoming = 10000; // server -> client
                     
                     this.stompClient.connect(
                         { Authorization: 'Bearer ' + accessToken },


### PR DESCRIPTION
### 변경 내용
- web.xml 서블릿 버전 2.5 -> 3.1 로 변경
- WebSocket 기반 접속/해제 트래킹 기능 구현
- JSP 요청 및 REST API 요청 예외 처리 분리
  - GlobalExceptionHandler -> REST 전용
  - GlobalViewExceptionHandler -> JSP 전용

### 테스트
- WebSocket 접속 및 해제 시 콘솔 로그 확인 완료
- JSP 요청 시 JSP 에러 페이지 응답 확인
- API 요청 시 JSON 형태의 에러 응답 확인

### 기타
- 온라인 및 오프라인 유저 반환 REST API 추가 예정 